### PR TITLE
use group 'nogroup' in place to undefined 'nobody'

### DIFF
--- a/manifests/vardir.pp
+++ b/manifests/vardir.pp
@@ -29,7 +29,7 @@ class common::vardir {	# module vardir snippet
 			purge => true,		# purge all unmanaged files
 			force => true,		# also purge subdirs and links
 			owner => root,
-			group => nobody,
+			group => nogroup,
 			mode => 600,
 			backup => false,	# don't backup to filebucket
 			#before => File["${module_vardir}"],	# redundant
@@ -44,7 +44,7 @@ class common::vardir {	# module vardir snippet
 		recurse => true,		# recursively manage directory
 		purge => true,			# purge all unmanaged files
 		force => true,			# also purge subdirs and links
-		owner => root, group => nobody, mode => 600, backup => false,
+		owner => root, group => nogroup, mode => 600, backup => false,
 		require => File["${tmp}"],	# File['/var/lib/puppet/tmp/']
 	}
 }


### PR DESCRIPTION
It seems 'nobody' is for user and the equivalent for groups is 'nogroup'.